### PR TITLE
Added custom filename support

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 
 func main() {
 	openFileFlag := flag.Bool("open", false, "To open the HTML report once generated")
+	fileNameFlag := flag.String("filename", "prettyplan.html", "Specify a filename other than prettyplan.html")
 	flag.Parse()
 
 	assets := getAssets()
@@ -28,10 +29,10 @@ func main() {
 		return
 	}
 
-	writeReport("prettyplan.html", assets, plan)
+	writeReport(*fileNameFlag, assets, plan)
 
 	if *openFileFlag {
-		browser.OpenFile("prettyplan.html")
+		browser.OpenFile(*fileNameFlag)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 
 func main() {
 	openFileFlag := flag.Bool("open", false, "To open the HTML report once generated")
-	fileNameFlag := flag.String("filename", "prettyplan.html", "Specify a filename other than prettyplan.html")
+	fileNameFlag := flag.String("filename", "prettyplan-output.html", "Specify a filename other than prettyplan-output.html")
 	flag.Parse()
 
 	assets := getAssets()


### PR DESCRIPTION
This PR adds the `-filename <FILENAME>` option to the command-line. 

It also changes the default file name from `prettyplan.html` to `prettyplan-output.html`. This is because running `prettyplan -open` (with or without custom file name) would fail if a `prettyplan.html` local file (with content) exists:

```bash
▶ prettyplan-cli -open -filename panete.html
panic: html/template:prettyplan.html: "<" in attribute name: "</td>\n                          "

goroutine 1 [running]:
main.panicIfError(...)
	/Users/xxx/go/src/github.com/chrislewisdev/prettyplan-cli/main.go:41
main.writeReport(0x7ffeefbff63f, 0xb, 0xc0001482a0, 0xc00067f400)
	/Users/xxx/go/src/github.com/chrislewisdev/prettyplan-cli/main.go:117 +0x1fa
main.main()
	/Users/xxx/go/src/github.com/chrislewisdev/prettyplan-cli/main.go:32 +0x16b
```

Fixes: https://github.com/chrislewisdev/prettyplan-cli/issues/5