### PR TITLE
Allow to provide plan via stdin

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"html/template"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"time"
@@ -18,13 +19,14 @@ import (
 func main() {
 	openFileFlag := flag.Bool("open", false, "To open the HTML report once generated")
 	fileNameFlag := flag.String("filename", "prettyplan-output.html", "Specify a filename other than prettyplan-output.html")
+	stdinFlag := flag.Bool("stdin", false, "Whether to read the plan from stdin instead of running terraform")
 	flag.Parse()
 
 	assets := getAssets()
 
 	var plan *planInfo
 	var err error
-	if plan, err = getPlan(); err != nil {
+	if plan, err = getPlan(*stdinFlag); err != nil {
 		fmt.Println(err.Error())
 		return
 	}
@@ -90,8 +92,16 @@ func getRawPlan() ([]byte, error) {
 	return rawPlan, nil
 }
 
-func getPlan() (*planInfo, error) {
-	rawPlan, err := getRawPlan()
+func getPlan(stdinFlag bool) (*planInfo, error) {
+	var rawPlan []byte
+	var err error
+	if stdinFlag {
+		fmt.Println("Reading plan from stdin...")
+		rawPlan, err = ioutil.ReadAll(os.Stdin)
+	} else {
+		fmt.Println("Running terraform to get plan...")
+		rawPlan, err = getRawPlan()
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -79,7 +79,7 @@ type planInfo struct {
 	Parsed parse.Plan
 }
 
-func getPlan() (*planInfo, error) {
+func getRawPlan() ([]byte, error) {
 	rawPlan, err := exec.Command("terraform", "plan", "-no-color").Output()
 	if err != nil {
 		if exitError, ok := err.(*exec.ExitError); ok {
@@ -87,7 +87,14 @@ func getPlan() (*planInfo, error) {
 		}
 		return nil, fmt.Errorf("terraform plan failed! Output:\n %v", err.Error())
 	}
+	return rawPlan, nil
+}
 
+func getPlan() (*planInfo, error) {
+	rawPlan, err := getRawPlan()
+	if err != nil {
+		return nil, err
+	}
 	plan := parse.Parse(string(rawPlan))
 
 	return &planInfo{Raw: string(rawPlan), Parsed: plan}, nil


### PR DESCRIPTION
Currently, prettyplan-cli takes it upon himself to obtain
the plan to prettify by running `terraform plan` by itself.

However, there can be cases where this not an option:
 - `terraform` is not readily available in the PATH
 - Additional flags need to be passed to terraform
 - Terraform is invoked by a wrapper (such as terragrunt)

This adds an additional flag, `input`.
If set, `prettyplan-cli` expects the plan to be provided via stdin.

Resolves #9